### PR TITLE
Fix _version.py path

### DIFF
--- a/ebaysdk/__init__.py
+++ b/ebaysdk/__init__.py
@@ -13,7 +13,7 @@ def get_version():
     # Get the version
     VERSIONFILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "_version.py")
     version = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-    open(VERSIONFILE, "rt").read(), re.M).group(1)
+        open(VERSIONFILE, "rt").read(), re.M).group(1)
 
     return version
 


### PR DESCRIPTION
Fix a path issue with _version.py that prevented the module from being imported.

Since pip will install the library in an arbitrary folder, the path to the _version.py file could be incorrect.
