### PR TITLE
Require https for trading api

### DIFF
--- a/ebaysdk/__init__.py
+++ b/ebaysdk/__init__.py
@@ -490,7 +490,7 @@ class trading(ebaybase):
         self.api_config = {
             'domain' : 'api.ebay.com',
             'uri' : '/ws/api.dll',
-            'https' : False,
+            'https' : True,
             'siteid' : '0',
             'response_encoding' : 'XML',
             'request_encoding' : 'XML',


### PR DESCRIPTION
The Trading api now requires HTTPS. This just makes it the default in config options for `trading`.
