### PR TITLE
Normalize the Shopping, Trading, and Finding modules __init__ methods

### DIFF
--- a/ebaysdk/__init__.py
+++ b/ebaysdk/__init__.py
@@ -319,9 +319,8 @@ class shopping(ebaybase):
 
         ebaybase.__init__(self, method='POST', **kwargs)
 
-        if https:
-            print "HTTPS is not supported on the Shopping API. HTTPS has been set to False"
-            https = False
+        if https and self.debug:
+            print "HTTPS is not supported on the Shopping API."
 
         self.api_config = {
             'domain'    : domain,
@@ -501,9 +500,8 @@ class trading(ebaybase):
 
         ebaybase.__init__(self, method='POST', **kwargs)
 
-        if not https:
-            print "HTTPS is required on the Trading API. HTTPS has been set to True"
-            https = True
+        if not https and self.debug:
+            print "HTTPS is required on the Trading API."
 
         self.api_config = {
             'domain'    : domain,


### PR DESCRIPTION
Normalize the Shopping, Trading, and Finding modules

The modules now allow the appid, certid, and devid to be set
when they are initialized, as well as via a yaml config file.

I also removed the username/password authorization option for
the trading API, since it seems it has been depricated in favor
of the user token.

Since the trading API doesn't allow http access, only https, if
a user tries to pass in https=False to the trading init function,
they will now get an info message, and it will be set to true. The same
goes for the other modules and their respective https defaults.

Maybe you can speak into a use case for the username/password auth w/ Shopping endpoint? When I attempted to use it without a token, it didn't work - but I suppose it might work on an internal api if there is one?

If the username/password is needed, I can always add them back.
