### PR TITLE
Call to prepare XML should be done only if data is present fixes #29

### DIFF
--- a/ebaysdk/__init__.py
+++ b/ebaysdk/__init__.py
@@ -193,12 +193,12 @@ class ebaybase(object):
 
         return xml
 
-    def execute(self, verb, data):
+    def execute(self, verb, data=None):
         "Executes the HTTP request."
 
         self.verb = verb
 
-        self.call_xml = self._to_xml(data)
+        self.call_xml = self._to_xml(data) if data else ''
         self.prepare()
 
         self._reset()

--- a/samples/trading.py
+++ b/samples/trading.py
@@ -92,6 +92,19 @@ def feedback(opts):
     else:
         print "Sell more, buy more.."
 
+
+def getTokenStatus(opts):
+    api = trading(debug=opts.debug, config_file=opts.yaml, appid=opts.appid,
+                  certid=opts.certid, devid=opts.devid, warnings=False)
+
+    api.execute('GetTokenStatus')
+
+    if api.error():
+        raise Exception(api.error())
+
+    dump(api)
+
+
 def verifyAddItem(opts):
     """http://www.utilities-online.info/xmltojson/#.UXli2it4avc
     """


### PR DESCRIPTION
execute() should have data initialised with None
Hence, if no data is present, we should not call for preparation of XML
This would allow making calls like **GetTokenStatus**, which cannot be made with the current implementation.
