### PR TITLE
Python2 compatibility fix on str() function

### DIFF
--- a/ebaysdk/__init__.py
+++ b/ebaysdk/__init__.py
@@ -247,7 +247,7 @@ class ebaybase(object):
         "Returns a BeautifulSoup object of the response."
 
         if not self._response_soup:
-            self._response_soup = BeautifulStoneSoup(str(self._response_content, encoding='utf-8'))
+            self._response_soup = BeautifulStoneSoup(self._response_content.decode('utf-8'))
 
         return self._response_soup
 


### PR DESCRIPTION
Python2 `str` builtin function has no `encoding` parameter.
