### PR TITLE
shopping API uses X-EBAY-API-SITE-ID not X-EBAY-API-SITEID

### DIFF
--- a/ebaysdk/__init__.py
+++ b/ebaysdk/__init__.py
@@ -516,7 +516,7 @@ class shopping(ebaybase):
         headers = {
             "X-EBAY-API-VERSION": self.api_config.get('version', ''),
             "X-EBAY-API-APP-ID":  self.api_config.get('appid', ''),
-            "X-EBAY-API-SITEID":  self.api_config.get('siteid', ''),
+            "X-EBAY-API-SITE-ID":  self.api_config.get('siteid', ''),
             "X-EBAY-API-CALL-NAME": self.verb,
             "X-EBAY-API-REQUEST-ENCODING": "XML",
             "Content-Type": "text/xml"


### PR DESCRIPTION
This is a fix for the shopping API to use sites other than the default.

There is a similar X-EBAY-API-SITEID on trading and merchandising classes.  I don't think merchandising used either spelling of the SITE-ID header as far as I can tell and I ran out of patience with the documentation before I checked on trading.  I don't know if others like finding would need something similar.
