### PR TITLE
added shim for unicode type in Python 3

### DIFF
--- a/ebaysdk/response.py
+++ b/ebaysdk/response.py
@@ -13,7 +13,7 @@ import datetime
 from collections import defaultdict
 import json
 
-from ebaysdk.utils import get_dom_tree, python_2_unicode_compatible
+from ebaysdk.utils import get_dom_tree, python_2_unicode_compatible, unicode
 from ebaysdk import log
 
 @python_2_unicode_compatible
@@ -52,7 +52,7 @@ class ResponseDataObject(object):
         setattr(self, name, value)
 
     def _load_dict(self, mydict, datetime_nodes):
-        
+
         for a in mydict.items():
 
             if isinstance(a[1], dict):
@@ -66,11 +66,11 @@ class ResponseDataObject(object):
                         objs.append(i)
                     else:
                         objs.append(ResponseDataObject(i, datetime_nodes))
-                
+
                 setattr(self, a[0], objs)
             else:
                 self._setattr(a[0], a[1], datetime_nodes)
-                
+
 class Response(object):
     '''
     <?xml version='1.0' encoding='UTF-8'?>
@@ -124,7 +124,7 @@ class Response(object):
     >>> len(item.shipping.c) == 2
     True
     '''
-    
+
     def __init__(self, obj, verb=None, list_nodes=[], datetime_nodes=[], parse_response=True):
         self._list_nodes=copy.copy(list_nodes)
         self._obj = obj
@@ -191,7 +191,7 @@ class Response(object):
                     dd[k].append(v)
 
             d = {t.tag: dict((k, self._pullval(v)) for k, v in dd.items())}
-            #d = {t.tag: {k:v[0] if len(v) == 1 else v for k, v in dd.items()}}    
+            #d = {t.tag: {k:v[0] if len(v) == 1 else v for k, v in dd.items()}}
 
             # TODO: Optimizations? Forces a node to type list
             parent_path = self._get_node_path(t)
@@ -217,7 +217,7 @@ class Response(object):
 
     def _parse_xml(self, xml):
         return get_dom_tree(xml)
-        
+
     def _get_node_tag(self, node):
         return node.tag.replace('{' + node.nsmap.get(node.prefix, '') + '}', '')
 

--- a/ebaysdk/utils.py
+++ b/ebaysdk/utils.py
@@ -9,8 +9,14 @@ import sys
 
 from lxml import etree as ET
 
-if sys.version_info[0] >= 3:
+# shim so isinstance(..., unicode) can work in Python 3
+#
+# to do this in other modules: from ebaysdk.utils import unicode
+if sys.version_info[0] < 3
+    unicode = unicode
+else:
     unicode = str
+
 
 def python_2_unicode_compatible(klass):
     """

--- a/ebaysdk/utils.py
+++ b/ebaysdk/utils.py
@@ -12,7 +12,7 @@ from lxml import etree as ET
 # shim so isinstance(..., unicode) can work in Python 3
 #
 # to do this in other modules: from ebaysdk.utils import unicode
-if sys.version_info[0] < 3
+if sys.version_info[0] < 3:
     unicode = unicode
 else:
     unicode = str

--- a/ebaysdk/utils.py
+++ b/ebaysdk/utils.py
@@ -9,6 +9,9 @@ import sys
 
 from lxml import etree as ET
 
+if sys.version_info[0] >= 3:
+    unicode = str
+
 def python_2_unicode_compatible(klass):
     """
     A decorator that defines __unicode__ and __str__ methods under Python 2.
@@ -112,7 +115,7 @@ def dict2xml(root):
     ...            '@attrs': common_attrs,
     ...            '#text': 'mydevid'
     ...        },
-    ...    },            
+    ...    },
     ...    {'@attrs': {'Name': 'AppId', 'NameFormat': 'String', 'FriendlyName': 'ApplicationID'},
     ...        'urn:AttributeValue': {
     ...            '@attrs': common_attrs,
@@ -124,7 +127,7 @@ def dict2xml(root):
     ...            '@attrs': common_attrs,
     ...            '#text': 'mycertid',
     ...        },
-    ...    },        
+    ...    },
     ...    ],
     ... }
     >>> print(dict2xml(attrdict))
@@ -140,7 +143,7 @@ def dict2xml(root):
 
             if isinstance(root[key], dict):
                 attrs, value = attribute_check(root[key])
-                
+
                 if not value:
                     value = dict2xml(root[key])
                 elif isinstance(value, dict):
@@ -151,11 +154,11 @@ def dict2xml(root):
                     attrs_sp = ' '
 
                 xml = '%(xml)s<%(tag)s%(attrs_sp)s%(attrs)s>%(value)s</%(tag)s>' % \
-                    {'tag': key, 'xml': xml, 'attrs': ' '.join(attrs), 
-                     'value': smart_encode(value), 'attrs_sp': attrs_sp}                          
+                    {'tag': key, 'xml': xml, 'attrs': ' '.join(attrs),
+                     'value': smart_encode(value), 'attrs_sp': attrs_sp}
 
             elif isinstance(root[key], list):
-                
+
                 for item in root[key]:
                     attrs, value = attribute_check(item)
 
@@ -163,7 +166,7 @@ def dict2xml(root):
                         value = dict2xml(item)
                     elif isinstance(value, dict):
                         value = dict2xml(value)
-                    
+
                     attrs_sp = ''
                     if len(attrs) > 0:
                         attrs_sp = ' '
@@ -171,7 +174,7 @@ def dict2xml(root):
                     xml = '%(xml)s<%(tag)s%(attrs_sp)s%(attrs)s>%(value)s</%(tag)s>' % \
                         {'xml': xml, 'tag': key, 'attrs': ' '.join(attrs),
                          'value': smart_encode(value), 'attrs_sp': attrs_sp}
- 
+
             else:
                 value = root[key]
                 xml = '%(xml)s<%(tag)s>%(value)s</%(tag)s>' % \
@@ -245,12 +248,12 @@ def perftest_dict2xml():
         ],
         'sortOrder': 'StartTimeNewest'
     }
-    
-    xml = dict2xml(sample_dict)   
+
+    xml = dict2xml(sample_dict)
 
 if __name__ == '__main__':
 
-    import timeit    
+    import timeit
     print("perftest_dict2xml() %s" % \
         timeit.timeit("perftest_dict2xml()", number=50000,
                       setup="from __main__ import perftest_dict2xml"))
@@ -258,4 +261,3 @@ if __name__ == '__main__':
     import doctest
     failure_count, test_count = doctest.testmod()
     sys.exit(failure_count)
-


### PR DESCRIPTION
`ebaysdk` had `isinstance(..., unicode)` in a couple of places, which of course doesn't work in Python 3.

Changed things so `ebaysdk.utils.unicode` is properly defined in Python 2 and 3, and can be imported into other modules as needed.

This should fix #88.