### PR TITLE
Added str conversion of siteid

### DIFF
--- a/ebaysdk/trading/__init__.py
+++ b/ebaysdk/trading/__init__.py
@@ -681,7 +681,7 @@ class Connection(BaseConnection):
             "X-EBAY-API-DEV-NAME": self.config.get('devid', ''),
             "X-EBAY-API-APP-NAME": self.config.get('appid', ''),
             "X-EBAY-API-CERT-NAME": self.config.get('certid', ''),
-            "X-EBAY-API-SITEID": self.config.get('siteid', ''),
+            "X-EBAY-API-SITEID": str(self.config.get('siteid', '')),
             "X-EBAY-API-CALL-NAME": self.verb,
             "Content-Type": "text/xml"
         }


### PR DESCRIPTION
Fixes requests InvalidHeader-exception for when `Trading` class is initialized with integer siteid parameter.
`Trading(appid=appid, devid=devid, certid=certid, siteid=77)` currently causes `InvalidHeader: Header value 77 must be of type str or bytes, not <type 'int'>` with requests > 2.10 or so.