### PR TITLE
Specify encoding when reading version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import codecs
 from setuptools import setup, find_packages
 import re
 import os
@@ -23,8 +24,8 @@ PKG = 'ebaysdk'
 # Get the version
 VERSIONFILE = os.path.join(PKG, "__init__.py")
 version = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                    open(VERSIONFILE, "rt").read(), re.M).group(1)
-
+                    codecs.open(VERSIONFILE, "r", encoding="utf-8").read(),
+                    re.M).group(1)
 
 long_desc = """This SDK is a programatic inteface into the eBay
 APIs. It simplifies development and cuts development time by standerizing


### PR DESCRIPTION
- On systems that don't use UTF-8 as the default encoding a UnicodeDecodeError
  is raised during setup. This fix uses `codecs.open` to specify UTF-8 encoding
  when reading `ebaysdk/__init__.py` for the version.

fixes #182 