### PR TITLE
added 'getmyebaysellingresponse.activelist.itemarray.item' to base_list_nodes

### DIFF
--- a/ebaysdk/trading/__init__.py
+++ b/ebaysdk/trading/__init__.py
@@ -217,6 +217,7 @@ class Connection(BaseConnection):
             'getmembermessagesresponse.abstractrequest.outputselector',
             'getmyebaybuyingresponse.abstractrequest.outputselector',
             'getmyebaysellingresponse.abstractrequest.outputselector',
+            'getmyebaysellingresponse.activelist.itemarray.item',
             'getmymessagesresponse.abstractrequest.outputselector',
             'getnotificationpreferencesresponse.abstractrequest.outputselector',
             'getordersresponse.abstractrequest.outputselector',


### PR DESCRIPTION
This change makes the item attribute of response.reply.activelist.ItemArray to be returned always as a list, event on a single result.

Single result:
` 'ActiveList': {'ItemArray': {'Item': [{'ItemID': '110388339347', 'SellingStatus': None, 'ShippingDetails': None, 'Title': 'Test Item'}]}}`