### PR TITLE
Set Finding API to use https by default

### DIFF
--- a/ebaysdk/finding/__init__.py
+++ b/ebaysdk/finding/__init__.py
@@ -55,7 +55,7 @@ class Connection(BaseConnection):
         appid         -- eBay application id
         siteid        -- eBay country site id (default: EBAY-US)
         version       -- version number (default: 1.0.0)
-        https         -- execute of https (default: False)
+        https         -- execute of https (default: True)
         proxy_host    -- proxy hostname
         proxy_port    -- proxy port number
         timeout       -- HTTP request timeout (default: 20)
@@ -73,7 +73,7 @@ class Connection(BaseConnection):
         # override yaml defaults with args sent to the constructor
         self.config.set('domain', kwargs.get('domain', 'svcs.ebay.com'))
         self.config.set('uri', '/services/search/FindingService/v1')
-        self.config.set('https', False)
+        self.config.set('https', True)
         self.config.set('warnings', True)
         self.config.set('errors', True)
         self.config.set('siteid', 'EBAY-US')


### PR DESCRIPTION
Per the eBay developer announcement, [Finding API is Discontinuing Support for HTTP](https://developer.ebay.com/news/https-only-finding-api) by October 1, 2019. If HTTPS is not used, then all requests to the Finding API will fail.

This change sets the base url for Finding API to use HTTPS by default.