### PR TITLE
Correct docstrings - warnings & errors

### DIFF
--- a/ebaysdk/finding/__init__.py
+++ b/ebaysdk/finding/__init__.py
@@ -50,7 +50,8 @@ class Connection(BaseConnection):
         domain        -- API endpoint (default: svcs.ebay.com)
         config_file   -- YAML defaults (default: ebay.yaml)
         debug         -- debugging enabled (default: False)
-        warnings      -- warnings enabled (default: False)
+        warnings      -- warnings enabled (default: True)
+        errors        -- errors enabled (default: True)
         uri           -- API endpoint uri (default: /services/search/FindingService/v1)
         appid         -- eBay application id
         siteid        -- eBay country site id (default: EBAY-US)

--- a/ebaysdk/inventorymanagement/__init__.py
+++ b/ebaysdk/inventorymanagement/__init__.py
@@ -128,7 +128,8 @@ class Connection(BaseConnection):
         domain        -- API endpoint (default: api.ebay.com)
         config_file   -- YAML defaults (default: ebay.yaml)
         debug         -- debugging enabled (default: False)
-        warnings      -- warnings enabled (default: False)
+        warnings      -- warnings enabled (default: True)
+        errors        -- errors enabled (default: True)
         uri           -- API endpoint uri (default: /selling/inventory/v1)
         token         -- eBay application/user token
         version       -- version number (default: 1.0.0)

--- a/ebaysdk/merchandising/__init__.py
+++ b/ebaysdk/merchandising/__init__.py
@@ -40,7 +40,8 @@ class Connection(FindingConnection):
         domain        -- API endpoint (default: open.api.ebay.com)
         config_file   -- YAML defaults (default: ebay.yaml)
         debug         -- debugging enabled (default: False)
-        warnings      -- warnings enabled (default: False)
+        warnings      -- warnings enabled (default: True)
+        errors        -- errors enabled (default: True)
         uri           -- API endpoint uri (default: /MerchandisingService)
         appid         -- eBay application id
         siteid        -- eBay country site id (default: 0 (US))

--- a/ebaysdk/policies/__init__.py
+++ b/ebaysdk/policies/__init__.py
@@ -32,7 +32,8 @@ class Connection(BaseConnection):
         domain        -- API endpoint (default: svcs.ebay.com)
         config_file   -- YAML defaults (default: ebay.yaml)
         debug         -- debugging enabled (default: False)
-        warnings      -- warnings enabled (default: False)
+        warnings      -- warnings enabled (default: True)
+        errors        -- errors enabled (default: True)
         uri           -- API endpoint uri (default: /services/selling/v1/SellerProfilesManagementService)
         appid         -- eBay application id
         siteid        -- eBay country site id (default: EBAY-US)

--- a/ebaysdk/trading/__init__.py
+++ b/ebaysdk/trading/__init__.py
@@ -60,7 +60,8 @@ class Connection(BaseConnection):
         domain        -- API endpoint (default: api.ebay.com)
         config_file   -- YAML defaults (default: ebay.yaml)
         debug         -- debugging enabled (default: False)
-        warnings      -- warnings enabled (default: False)
+        warnings      -- warnings enabled (default: True)
+        errors        -- errors enabled (default: True)
         uri           -- API endpoint uri (default: /ws/api.dll)
         appid         -- eBay application id
         devid         -- eBay developer id


### PR DESCRIPTION
These changes only affect docstrings. I had been trying to figure out how to disable warnings when I stumbled into the `warnings` and `errors` configuration options. Only then did I notice the docstrings were incorrect and missing information.
