### PR TITLE
Remove samples and tests from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     author_email="tkeefer@gmail.com",
     url="https://github.com/timotheus/ebaysdk-python",
     license="COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0",
-    packages=find_packages(),
+    packages=find_packages(include=['ebaysdk', 'ebaysdk.*'),
     provides=[PKG],
     install_requires=['lxml', 'requests'], #requirements_file_to_list(),
     test_suite='tests',


### PR DESCRIPTION
When installing the package, `tests` and `samples` were being put into
my `site-packages`. This fixes that for me.