### PR TITLE
add iaf_token to shopping API

### DIFF
--- a/ebaysdk/shopping/__init__.py
+++ b/ebaysdk/shopping/__init__.py
@@ -79,6 +79,7 @@ class Connection(BaseConnection):
         self.config.set('proxy_host', None)
         self.config.set('proxy_port', None)
         self.config.set('appid', None)
+        self.config.set('iaf_token', None)
         self.config.set('version', '799')
         self.config.set('trackingid', None)
         self.config.set('trackingpartnercode', None)
@@ -145,6 +146,10 @@ class Connection(BaseConnection):
             headers.update({
                 "X-EBAY-API-TRACKING-PARTNER-CODE": self.config.get('trackingpartnercode')
             })
+
+        if self.config.get('iaf_token', None):
+            headers["X-EBAY-API-IAF-TOKEN"] = self.config.get('iaf_token')
+    
 
         return headers
 


### PR DESCRIPTION
recently ebay changed its shopping API so that they work only with a valid `X-EBAY-API-IAF-TOKEN` header, this pull request will fix the shopping APP to accept and include `iaf_token` in the request.
just pass the `iaf_token` parameter with a valid token to the `Connection` object to fix!